### PR TITLE
An exception thrown from 'insert' function is not wrapped by wrapException

### DIFF
--- a/src/Database/Cassandra/Basic.hs
+++ b/src/Database/Cassandra/Basic.hs
@@ -265,7 +265,7 @@ insert
 insert cf k cl row = withCassandraPool $ \ Cassandra{..} -> do
   let insCol cp c = do
         c' <- mkThriftCol c
-        C.insert (cProto, cProto) k cp c' cl
+        wrapException $ C.insert (cProto, cProto) k cp c' cl
   forM_ row $ \ c -> do
     case c of
       Column{} -> do


### PR DESCRIPTION
However, an exception thrown from other functions is wrapped.
